### PR TITLE
add support for configurable registry and resolver paths

### DIFF
--- a/packages/shiki/src/highlighter.ts
+++ b/packages/shiki/src/highlighter.ts
@@ -47,6 +47,14 @@ export async function getHighlighter(options: HighlighterOptions): Promise<Highl
   const _defaultTheme = themes[0]
   await _registry.loadLanguages(_languages)
 
+  if (options.paths?.themes) {
+    _registry.themesPath = options.paths.themes
+  }
+
+  if (options.paths?.languages) {
+    _resolver.languagesPath = options.paths.languages
+  }
+
   function getTheme(theme: IThemeRegistration) {
     const _theme = theme ? _registry.getTheme(theme) : _defaultTheme
     if (!_theme) {

--- a/packages/shiki/src/registry.ts
+++ b/packages/shiki/src/registry.ts
@@ -5,6 +5,8 @@ import { Theme } from './themes'
 import { Resolver } from './resolver'
 
 export class Registry extends TextMateRegistry {
+  public themesPath: string = 'themes/'
+
   private _resolvedThemes: Record<string, IShikiTheme> = {}
   private _resolvedGammer: Record<string, IGrammar> = {}
 
@@ -23,7 +25,7 @@ export class Registry extends TextMateRegistry {
   public async loadTheme(theme: Theme | IShikiTheme | string) {
     if (typeof theme === 'string') {
       if (!this._resolvedThemes[theme]) {
-        this._resolvedThemes[theme] = await fetchTheme(`themes/${theme}.json`)
+        this._resolvedThemes[theme] = await fetchTheme(`${this.themesPath}${theme}.json`)
       }
       return this._resolvedThemes[theme]
     } else {

--- a/packages/shiki/src/resolver.ts
+++ b/packages/shiki/src/resolver.ts
@@ -10,6 +10,8 @@ import { fetchGrammar } from './loader'
 import { ILanguageRegistration } from './types'
 
 export class Resolver implements RegistryOptions {
+  public languagesPath: string = 'languages/'
+
   private readonly languageMap: { [langIdOrAlias: string]: ILanguageRegistration } = {}
   private readonly scopeToLangMap: { [scope: string]: ILanguageRegistration } = {}
 
@@ -44,7 +46,9 @@ export class Resolver implements RegistryOptions {
       return lang.grammar
     }
 
-    const g = await fetchGrammar(languages.includes(lang) ? `languages/${lang.path}` : lang.path)
+    const g = await fetchGrammar(
+      languages.includes(lang) ? `${this.languagesPath}${lang.path}` : lang.path
+    )
     lang.grammar = g
     return g
   }

--- a/packages/shiki/src/types.ts
+++ b/packages/shiki/src/types.ts
@@ -7,6 +7,7 @@ export interface HighlighterOptions {
   theme?: IThemeRegistration
   langs?: (Lang | ILanguageRegistration)[]
   themes?: IThemeRegistration[]
+  paths?: IHighlighterPaths
 }
 
 export interface Highlighter {
@@ -31,6 +32,11 @@ export interface Highlighter {
   // getRawCSS?(): string
 
   // codeToImage?(): string
+}
+
+export interface IHighlighterPaths {
+  themes?: string
+  languages?: string
 }
 
 export interface ILanguageRegistration {


### PR DESCRIPTION
Maybe something like this?

not too sure about the naming of the properties but it is specific to themes/languages after all.

let me know what you think, i think this is better/safer than trying to detect paths being passed in

it feels like the registry should own both, but the resolver is what actually does the path interpolation for languages.